### PR TITLE
Renamed toString() to get(), implemented __toString()

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,15 @@ You can also return the result as a string:
 ```php
 $image = ImageResize::createFromString(base64_decode('R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw=='));
 $image->scale(50);
-$result = $image->toString();
+$result = $image->get();
+```
+
+Magic `__toString()` is also supported:
+
+```php
+$image = ImageResize::createFromString(base64_decode('R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw=='));
+$image->resize(10, 10);
+$result = (string)$image;
 ```
 
 Displaying
@@ -145,7 +153,7 @@ $image->save('image2.jpg');
 
 By default they are set to 75 and 0 respectively. See the manual entries for [`imagejpeg()`](http://www.php.net/manual/en/function.imagejpeg.php) and [`imagepng()`](http://www.php.net/manual/en/function.imagepng.php) for more info.
 
-You can also pass the quality directly to the `save()`, `output()` and `toString()` methods:
+You can also pass the quality directly to the `save()`, `output()` and `get()` methods:
 
 ```php
 $image = new ImageResize('image.jpg');
@@ -158,7 +166,7 @@ $image->output(IMAGETYPE_PNG, 4);
 
 $image = new ImageResize('image.jpg');
 $image->scale(50);
-$result = $image->toString(IMAGETYPE_PNG, 4);
+$result = $image->get(IMAGETYPE_PNG, 4);
 ```
 
 We're passing `null` for the image type in the example above to skip over it and provide the quality. In this case, the image type is assumed to be the same as the input.

--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -228,16 +228,25 @@ class ImageResize
     }
 
     /**
-     * Return image as string
+     * Get image as string
      *
      * @param int $image_type
      * @param int $quality
      * @return string
      */
-    public function toString($image_type = null, $quality = null){
+    public function get($image_type = null, $quality = null){
         ob_start();
         $this->save(null, $image_type, $quality);
         return ob_get_clean();
+    }
+
+    /**
+    * Convert the image to string with the current settings
+    *
+    * @return string
+    */
+    public function __toString(){
+        return $this->get();
     }
 
     /**

--- a/test/Test.php
+++ b/test/Test.php
@@ -203,9 +203,15 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(600, substr(decoct(fileperms($filename)), 3));
     }
 
+    public function testGet(){
+        $resize = ImageResize::createFromString(base64_decode($this->image_string));
+        $image = $resize->get();
+        $this->assertEquals(79, strlen($image));
+    }
+
     public function testToString(){
         $resize = ImageResize::createFromString(base64_decode($this->image_string));
-        $image = $resize->toString();
+        $image = (string)$resize;
         $this->assertEquals(79, strlen($image));
     }
 


### PR DESCRIPTION
Get is a more appropriate name given that the function takes parameters which influence the resulting image (quality and image type). Also implemented the __toString() magic method.