### PR TITLE
Code cleanup and slight refactor

### DIFF
--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -253,7 +253,7 @@ class ImageResize
     *
     * @return string
     */
-    public function __toString(){
+    public function __toString() {
         return $this->getImageAsString();
     }
 

--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -78,16 +78,6 @@ class ImageResize
     }
 
     /**
-     * Get image size from string
-     *
-     * @param string $imagedata
-     * @return array
-     */
-    protected function getImagesizeFromString($imagedata){
-        return @getimagesize('data://application/octet-stream;base64,' . base64_encode($imagedata));
-    }
-
-    /**
      * Load image from string
      *
      * @param string $imagedata
@@ -96,7 +86,8 @@ class ImageResize
      */
     public function loadFromString($imagedata)
     {
-        $image_info = $this->getImagesizeFromString($imagedata);
+        $image_info = getimagesize('data://application/octet-stream;base64,' . base64_encode($imagedata));
+
         if(!$image_info) {
             throw new \Exception('Could not load image from string');
         }

--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -129,10 +129,10 @@ class ImageResize
      */
     public function loadFromFile($filename)
     {
-        $image_info = getimagesize($filename);
+        $image_info = @getimagesize($filename);
 
         if (!$image_info) {
-            throw new \Exception('Could not read ' . $filename);
+            throw new \Exception('Could not read ' . ($filename ?: 'file'));
         }
 
         list (

--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -98,7 +98,17 @@ class ImageResize
             $this->source_type
         ) = $image_info;
 
-        $this->source_image = imagecreatefromstring($imagedata);
+        switch ($this->source_type) {
+            case IMAGETYPE_GIF:
+            case IMAGETYPE_JPEG:
+            case IMAGETYPE_PNG:
+                $this->source_image = imagecreatefromstring($imagedata);
+                break;
+
+            default:
+                throw new \Exception('Unsupported image type');
+                break;
+        }
 
         return $this->resize($this->getSourceWidth(), $this->getSourceHeight());
     }

--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -229,16 +229,22 @@ class ImageResize
     }
 
     /**
-     * Get image as string
+     * Convert the image to string
      *
      * @param int $image_type
      * @param int $quality
      * @return string
      */
-    public function get($image_type = null, $quality = null){
-        ob_start();
-        $this->save(null, $image_type, $quality);
-        return ob_get_clean();
+    public function getImageAsString($image_type = null, $quality = null){
+        $string_temp = tempnam('', '');
+
+        $this->save($string_temp, $image_type, $quality);
+
+        $string = file_get_contents($string_temp);
+
+        unlink($string_temp);
+
+        return $string;
     }
 
     /**
@@ -247,7 +253,7 @@ class ImageResize
     * @return string
     */
     public function __toString(){
-        return $this->get();
+        return $this->getImageAsString();
     }
 
     /**

--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -9,12 +9,12 @@ use \Exception;
  */
 class ImageResize
 {
-    const cropTOP = 1;
-    const cropCENTRE = 2;
-    const cropCENTER = 2;
-    const cropBOTTOM = 3;
-    const cropLEFT = 4;
-    const cropRIGHT = 5;
+    const CROPTOP = 1;
+    const CROPCENTRE = 2;
+    const CROPCENTER = 2;
+    const CROPBOTTOM = 3;
+    const CROPLEFT = 4;
+    const CROPRIGHT = 5;
     
     public $quality_jpg = 75;
     public $quality_png = 0;
@@ -70,7 +70,7 @@ class ImageResize
      * @param string|null $filename
      * @throws \Exception
      */
-    public function __construct($filename=null)
+    public function __construct($filename = null)
     {
         if(!empty($filename)) {
             $this->load($filename);
@@ -135,18 +135,19 @@ class ImageResize
         switch ($this->source_type) {
             case IMAGETYPE_GIF:
                 $this->source_image = imagecreatefromgif($filename);
-            break;
+                break;
 
             case IMAGETYPE_JPEG:
                 $this->source_image = imagecreatefromjpeg($filename);
-            break;
+                break;
 
             case IMAGETYPE_PNG:
                 $this->source_image = imagecreatefrompng($filename);
-            break;
+                break;
 
             default:
                 throw new \Exception('Unsupported image type');
+                break;
         }
 
         return $this->resize($this->getSourceWidth(), $this->getSourceHeight());
@@ -172,17 +173,17 @@ class ImageResize
                 imagecolortransparent($dest_image, $background);
                 imagefill($dest_image, 0, 0 , $background);
                 imagesavealpha($dest_image, true);
-            break;
+                break;
 
             case IMAGETYPE_JPEG:
                 $background = imagecolorallocate($dest_image, 255, 255, 255);
                 imagefilledrectangle($dest_image, 0, 0, $this->getDestWidth(), $this->getDestHeight(), $background);
-            break;
+                break;
 
             case IMAGETYPE_PNG:
                 imagealphablending($dest_image, false);
                 imagesavealpha($dest_image, true);
-            break;
+                break;
         }
 
         imagecopyresampled(
@@ -201,7 +202,7 @@ class ImageResize
         switch ($image_type) {
             case IMAGETYPE_GIF:
                 imagegif($dest_image, $filename);
-            break;
+                break;
 
             case IMAGETYPE_JPEG:
                 if ($quality === null) {
@@ -209,7 +210,7 @@ class ImageResize
                 }
 
                 imagejpeg($dest_image, $filename, $quality);
-            break;
+                break;
 
             case IMAGETYPE_PNG:
                 if ($quality === null) {
@@ -217,7 +218,7 @@ class ImageResize
                 }
 
                 imagepng($dest_image, $filename, $quality);
-            break;
+                break;
         }
 
         if ($permissions) {
@@ -351,7 +352,7 @@ class ImageResize
      * @param integer $position
      * @return \static
      */
-    public function crop($width, $height, $allow_enlarge = false, $position = self::cropCENTER)
+    public function crop($width, $height, $allow_enlarge = false, $position = self::CROPCENTER)
     {
         if (!$allow_enlarge) {
             // this logic is slightly different to resize(),
@@ -435,17 +436,18 @@ class ImageResize
      * @param integer $position
      * @return integer
      */
-    protected function getCropPosition($expectedSize, $position = self::cropCENTER)
+    protected function getCropPosition($expectedSize, $position = self::CROPCENTER)
     {
         $size = 0;
         switch ($position) {
-            case self::cropBOTTOM:
-            case self::cropRIGHT:
+            case self::CROPBOTTOM:
+            case self::CROPRIGHT:
                 $size = $expectedSize;
                 break;
-            case self::cropCENTER:
-            case self::cropCENTRE:
+            case self::CROPCENTER:
+            case self::CROPCENTRE:
                 $size = $expectedSize / 2;
+                break;
         }
         return $size;
     }

--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -45,7 +45,7 @@ class ImageResize
      * @return ImageResize
      * @throws \Exception
      */
-    public static function createFromFile($filename){
+    public static function createFromFile($filename) {
         $s = new self();
         $s->loadFromFile($filename);
         return $s;
@@ -58,7 +58,7 @@ class ImageResize
      * @return ImageResize
      * @throws \exception
      */
-    public static function createFromString($imageData){
+    public static function createFromString($imageData) {
         $s = new self();
         $s->loadFromString($imageData);
         return $s;
@@ -236,7 +236,7 @@ class ImageResize
      * @param int $quality
      * @return string
      */
-    public function getImageAsString($image_type = null, $quality = null){
+    public function getImageAsString($image_type = null, $quality = null) {
         $string_temp = tempnam('', '');
 
         $this->save($string_temp, $image_type, $quality);

--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -47,7 +47,7 @@ class ImageResize
      */
     public static function createFromFile($filename){
         $s = new self();
-        $s->load($filename);
+        $s->loadFromFile($filename);
         return $s;
     }
 
@@ -72,8 +72,8 @@ class ImageResize
      */
     public function __construct($filename = null)
     {
-        if(!empty($filename)) {
-            $this->load($filename);
+        if (!empty($filename)) {
+            $this->loadFromFile($filename);
         }
     }
 
@@ -88,7 +88,7 @@ class ImageResize
     {
         $image_info = getimagesize('data://application/octet-stream;base64,' . base64_encode($imagedata));
 
-        if(!$image_info) {
+        if (!$image_info) {
             throw new \Exception('Could not load image from string');
         }
 
@@ -119,7 +119,7 @@ class ImageResize
      * @return \static
      * @throws Exception
      */
-    public function load($filename)
+    public function loadFromFile($filename)
     {
         $image_info = getimagesize($filename);
 

--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -96,7 +96,7 @@ class ImageResize
             $this->original_w,
             $this->original_h,
             $this->source_type
-            ) = $image_info;
+        ) = $image_info;
 
         $this->source_image = imagecreatefromstring($imagedata);
 

--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -72,8 +72,16 @@ class ImageResize
      */
     public function __construct($filename = null)
     {
-        if (!empty($filename)) {
+        if ($filename !== null) {
             $this->loadFromFile($filename);
+        } else {
+            // if no filename is provided, we want to throw an exception if
+            // the object was not created in one of it's static method
+            $backtrace = debug_backtrace();
+
+            if (!isset($backtrace[1]['class']) || $backtrace[1]['class'] != __CLASS__) {
+                throw new \Exception('No image provided');
+            }
         }
     }
 

--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -86,7 +86,7 @@ class ImageResize
      */
     public function loadFromString($imagedata)
     {
-        $image_info = getimagesize('data://application/octet-stream;base64,' . base64_encode($imagedata));
+        $image_info = @getimagesize('data://application/octet-stream;base64,' . base64_encode($imagedata));
 
         if (!$image_info) {
             throw new \Exception('Could not load image from string');

--- a/test/Test.php
+++ b/test/Test.php
@@ -16,12 +16,10 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
     private $unsupported_image = 'Qk08AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABAAAAAAAAYAAAASCwAAEgsAAAAAAAAAAAAA/38AAAAA';
     private $image_string = 'R0lGODlhAQABAIAAAAQCBP///yH5BAEAAAEALAAAAAABAAEAAAICRAEAOw==';
 
-    public function testLoadString() {
-        $resize = ImageResize::createFromString(base64_decode($this->image_string));
 
-        $this->assertEquals(IMAGETYPE_GIF, $resize->source_type);
-        $this->assertInstanceOf('\Eventviva\ImageResize', $resize);
-    }
+    /**
+     * Loading tests
+     */
 
     public function testLoadGif() {
         $image = $this->createImage(1, 1, 'gif');
@@ -47,13 +45,17 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Eventviva\ImageResize', $resize);
     }
 
-    /**
-     * @expectedException Exception
-     * @expectedExceptionMessage Unsupported image type
-     */
-    public function testInvalidString() {
-        ImageResize::createFromString(base64_decode($this->unsupported_image));
+    public function testLoadString() {
+        $resize = ImageResize::createFromString(base64_decode($this->image_string));
+
+        $this->assertEquals(IMAGETYPE_GIF, $resize->source_type);
+        $this->assertInstanceOf('\Eventviva\ImageResize', $resize);
     }
+
+
+    /**
+     * Bad load tests
+     */
 
     /**
      * @expectedException Exception
@@ -92,6 +94,19 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
 
         new ImageResize($filename);
     }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Unsupported image type
+     */
+    public function testInvalidString() {
+        ImageResize::createFromString(base64_decode($this->unsupported_image));
+    }
+
+
+    /**
+     * Resize tests
+     */
 
     public function testResizeToHeight() {
         $image = $this->createImage(200, 100, 'png');
@@ -143,6 +158,11 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(100, $resize->getDestHeight());
     }
 
+
+    /**
+     * Crop tests
+     */
+
     public function testCrop() {
         $image = $this->createImage(200, 100, 'png');
         $resize = new ImageResize($image);
@@ -175,6 +195,11 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(200, $resize->getDestWidth());
         $this->assertEquals(100, $resize->getDestHeight());
     }
+
+
+    /**
+     * Save tests
+     */
 
     public function testSaveGif() {
         $image = $this->createImage(200, 100, 'gif');
@@ -224,6 +249,11 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(600, substr(decoct(fileperms($filename)), 3));
     }
 
+
+    /**
+     * String test
+     */
+
     public function testGetImageAsString() {
         $resize = ImageResize::createFromString(base64_decode($this->image_string));
         $image = $resize->getImageAsString();
@@ -235,6 +265,11 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
         $image = (string)$resize;
         $this->assertEquals(43, strlen($image));
     }
+
+
+    /**
+     * Output tests
+     */
 
     public function testOutputGif() {
         $image = $this->createImage(200, 100, 'gif');
@@ -292,6 +327,11 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('image/png', $type);
     }
+
+
+    /**
+     * Helpers
+     */
 
     private function createImage($width, $height, $type) {
         if (!in_array($type, $this->image_types)) {

--- a/test/Test.php
+++ b/test/Test.php
@@ -56,11 +56,11 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
-     * @expectedExceptionMessage Filename cannot be empty
+     * @expectedException Exception
+     * @expectedExceptionMessage No image provided
      */
     public function testLoadNoFile() {
-        ImageResize::createFromFile(null);
+        new ImageResize(null);
     }
 
     /**

--- a/test/Test.php
+++ b/test/Test.php
@@ -14,9 +14,9 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
     );
 
     private $unsupported_image = 'Qk08AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABAAAAAAAAYAAAASCwAAEgsAAAAAAAAAAAAA/38AAAAA';
-    private $image_string = 'R0lGODlhDwAPAKECAAAAzMzM/////wAAACwAAAAADwAPAAACIISPeQHsrZ5ModrLlN48CXF8m2iQ3YmmKqVlRtW4MLwWACH+H09wdGltaXplZCBieSBVbGVhZCBTbWFydFNhdmVyIQAAOw==';
+    private $image_string = 'R0lGODlhAQABAIAAAAQCBP///yH5BAEAAAEALAAAAAABAAEAAAICRAEAOw==';
 
-    public function testLoadString(){
+    public function testLoadString() {
         $resize = ImageResize::createFromString(base64_decode($this->image_string));
 
         $this->assertEquals(IMAGETYPE_GIF, $resize->source_type);
@@ -49,10 +49,10 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Exception
-     * @expectedExceptionMessage Could not load image from string
+     * @expectedExceptionMessage Unsupported image type
      */
-    public function testInvalidString(){
-        ImageResize::createFromString($this->unsupported_image);
+    public function testInvalidString() {
+        ImageResize::createFromString(base64_decode($this->unsupported_image));
     }
 
     /**
@@ -69,6 +69,14 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
      */
     public function testLoadUnsupportedFile() {
         new ImageResize(__FILE__);
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Could not load
+     */
+    public function testLoadUnsupportedFileString() {
+        ImageResize::createFromString('');
     }
 
     /**
@@ -216,16 +224,16 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(600, substr(decoct(fileperms($filename)), 3));
     }
 
-    public function testGetImageAsString(){
+    public function testGetImageAsString() {
         $resize = ImageResize::createFromString(base64_decode($this->image_string));
         $image = $resize->getImageAsString();
-        $this->assertEquals(79, strlen($image));
+        $this->assertEquals(43, strlen($image));
     }
 
-    public function testToString(){
+    public function testToString() {
         $resize = ImageResize::createFromString(base64_decode($this->image_string));
         $image = (string)$resize;
-        $this->assertEquals(79, strlen($image));
+        $this->assertEquals(43, strlen($image));
     }
 
     public function testOutputGif() {

--- a/test/Test.php
+++ b/test/Test.php
@@ -149,7 +149,7 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
         $image = $this->createImage(200, 100, 'png');
         $resize = new ImageResize($image);
 
-        $resize->crop(50, 50, false, $resize::cropRIGHT);
+        $resize->crop(50, 50, false, $resize::CROPRIGHT);
 
         $reflection_class = new ReflectionClass('\Eventviva\ImageResize');
         $source_x = $reflection_class->getProperty('source_x');

--- a/test/Test.php
+++ b/test/Test.php
@@ -216,9 +216,9 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(600, substr(decoct(fileperms($filename)), 3));
     }
 
-    public function testGet(){
+    public function testGetImageAsString(){
         $resize = ImageResize::createFromString(base64_decode($this->image_string));
-        $image = $resize->get();
+        $image = $resize->getImageAsString();
         $this->assertEquals(79, strlen($image));
     }
 


### PR DESCRIPTION
Changes should be understandable from commit logs, most is just neatening things up a bit.

Only two public API changes, and these hadn't been tagged yet, so shouldn't affect many:
- `load()` is now `loadFromFile()`, to match `loadFromString`
- `get()` is now `getImageAsString()`

These changes affect code recently merged from @Sjaakmoes, so feedback on that is welcome.

I also have a quick question:
- Why do `createFromString()` and `createFromFile()` need to exists? They just point to `loadFromString()` and `loadFromFile()`, which are public anyway. We could just make `loadFromString()` and `loadFromFile()` static and I think it would be good enough.

What do you guys think?

Maybe don't tag this one just yet, incase things change that affect the public API.