### PR TITLE
Fix when open_basedir restriction is in effect

### DIFF
--- a/src/ImageResize.php
+++ b/src/ImageResize.php
@@ -213,7 +213,7 @@ class ImageResize
      */
     public function getImageAsString($image_type = null, $quality = null)
     {
-        $string_temp = tempnam('', '');
+        $string_temp = tempnam(sys_get_temp_dir(), '');
 
         $this->save($string_temp, $image_type, $quality);
 


### PR DESCRIPTION
Using an empty string as `$dir` parameter will not work if an open_basedir restriction is in effect.

See first comment on the [manual page](http://php.net/manual/fr/function.tempnam.php).