### PR TITLE
add quality_truecolor parameter

### DIFF
--- a/lib/ImageResize.php
+++ b/lib/ImageResize.php
@@ -18,6 +18,7 @@ class ImageResize
 
     public $quality_jpg = 75;
     public $quality_png = 0;
+    public $quality_truecolor = TRUE;
 
     public $interlace = 1;
 
@@ -143,12 +144,10 @@ class ImageResize
     {
         $image_type = $image_type ?: $this->source_type;
 
-        $dest_image = imagecreatetruecolor($this->getDestWidth(), $this->getDestHeight());
-
-        imageinterlace($dest_image, $this->interlace);
-
         switch ($image_type) {
             case IMAGETYPE_GIF:
+                $dest_image = imagecreatetruecolor($this->getDestWidth(), $this->getDestHeight());
+
                 $background = imagecolorallocatealpha($dest_image, 255, 255, 255, 1);
                 imagecolortransparent($dest_image, $background);
                 imagefill($dest_image, 0, 0 , $background);
@@ -156,15 +155,29 @@ class ImageResize
                 break;
 
             case IMAGETYPE_JPEG:
+                $dest_image = imagecreatetruecolor($this->getDestWidth(), $this->getDestHeight());
+
                 $background = imagecolorallocate($dest_image, 255, 255, 255);
                 imagefilledrectangle($dest_image, 0, 0, $this->getDestWidth(), $this->getDestHeight(), $background);
                 break;
 
             case IMAGETYPE_PNG:
+                if (!$this->quality_truecolor && !imageistruecolor($this->source_image)) {
+                    $dest_image = imagecreate($this->getDestWidth(), $this->getDestHeight());
+
+                    $background = imagecolorallocatealpha($dest_image, 255, 255, 255, 1);
+                    imagecolortransparent($dest_image, $background);
+                    imagefill($dest_image, 0, 0 , $background);
+                } else {
+                    $dest_image = imagecreatetruecolor($this->getDestWidth(), $this->getDestHeight());
+                }
+
                 imagealphablending($dest_image, false);
                 imagesavealpha($dest_image, true);
                 break;
         }
+
+        imageinterlace($dest_image, $this->interlace);
 
         imagecopyresampled(
             $dest_image,


### PR DESCRIPTION
Added new optional quality parameter, that allows to significantly reduce png file size.
By default this library converts palettized png files into truecolor images.
You can set $quality_truecolor to "false" to avoid convertation.

NOTE: palettized images have lesser quality! Because of this and for BC default value for $quality_truecolor is "true".

Test results for ~20000 images with different sizes and palettes:
Original folder size: 2GB
Resized folder without new parameter: 9,3GB (0 compression), 4GB (7 compression)
Resized folder with new parameter: 3,2GB (0 compression), 1,5GB (7 compression)