### PR TITLE
make ext-exif suggested instead of required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,10 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "ext-gd": "*",
-        "ext-exif": "*"
+        "ext-gd": "*"
+    },
+    "suggest": {
+        "ext-exif": "Auto-rotate jpeg files"
     },
     "autoload": {
         "classmap": ["lib"]

--- a/lib/ImageResize.php
+++ b/lib/ImageResize.php
@@ -108,6 +108,11 @@ class ImageResize
     // http://stackoverflow.com/a/28819866
     public function imageCreateJpegfromExif($filename){
       $img = imagecreatefromjpeg($filename);
+
+      if (!function_exists('exif_read_data')) {
+          return $img;
+      }
+
       $exif = @exif_read_data($filename);
 
       if (!$exif || !isset($exif['Orientation'])){


### PR DESCRIPTION
This change make the package work without ext-exif if it's not installed.