### PR TITLE
Added the ImageResizeException to the Readme and php unit test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,22 @@ $image
 ;
 ```
 
+Exceptions
+--------
+
+ImageResize throws ImageResizeException for it's own for errors. You can catch that or catch the general \Exception which it's extending.
+
+It is not to be expected, but should anything go horribly wrong mid way then notice or warning Errors could be shown from the PHP GD and Image Functions (http://php.net/manual/en/ref.image.php)
+
+```php
+try{
+    $image = new ImageResize(null);
+    echo "This line will not be printed";
+} catch (ImageResizeException $e) {
+    echo "Something went wrong" . $e->getMessage();  
+}
+```
+ 
 API Doc
 -------
 

--- a/test/Test.php
+++ b/test/Test.php
@@ -3,8 +3,9 @@
 include __DIR__.'/../lib/ImageResize.php';
 
 use \Eventviva\ImageResize;
+use \Eventviva\ImageResizeException;
 
-if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+if (version_compare(PHP_VERSION, '7.0.0') >= 0 && !class_exists('PHPUnit_Framework_TestCase')) {
     class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
 }
 
@@ -60,13 +61,12 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Eventviva\ImageResize', $resize);
     }
 
-
     /**
      * Bad load tests
      */
 
     /**
-     * @expectedException Exception
+     * @expectedException \Eventviva\ImageResizeException
      * @expectedExceptionMessage Could not read file
      */
     public function testLoadNoFile()
@@ -75,7 +75,7 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Eventviva\ImageResizeException
      * @expectedExceptionMessage Could not read file
      */
     public function testLoadUnsupportedFile()
@@ -84,7 +84,7 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Eventviva\ImageResizeException
      * @expectedExceptionMessage Could not read file
      */
     public function testLoadUnsupportedFileString()
@@ -93,7 +93,7 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Eventviva\ImageResizeException
      * @expectedExceptionMessage Unsupported image type
      */
     public function testLoadUnsupportedImage()
@@ -108,7 +108,7 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Eventviva\ImageResizeException
      * @expectedExceptionMessage Unsupported image type
      */
     public function testInvalidString()
@@ -398,7 +398,7 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
     private function createImage($width, $height, $type)
     {
         if (!in_array($type, $this->image_types)) {
-            throw new \Exception('Unsupported image type');
+            throw new ImageResizeException('Unsupported image type');
         }
 
         $image = imagecreatetruecolor($width, $height);
@@ -416,5 +416,43 @@ class ImageResizeTest extends PHPUnit_Framework_TestCase
         return tempnam(sys_get_temp_dir(), 'resize_test_image');
     }
 
+}
+
+class ImageResizeExceptionTest extends PHPUnit_Framework_TestCase
+{
+    public function testExceptionEmpty()
+    {
+        $e = new ImageResizeException();
+    
+        $this->assertEquals("", $e->getMessage());
+        $this->assertInstanceOf('\Eventviva\ImageResizeException', $e);
+    }
+    
+    public function testExceptionMessage()
+    {
+        $e = new ImageResizeException("General error");
+    
+        $this->assertEquals("General error", $e->getMessage());
+        $this->assertInstanceOf('\Eventviva\ImageResizeException', $e);
+    }
+    
+    public function testExceptionExtending()
+    {
+        $e = new ImageResizeException("General error");
+        
+        $this->assertInstanceOf('\Exception', $e);
+    }
+    
+    public function testExceptionThrown()
+    {
+        try{
+            throw new ImageResizeException("General error");
+        } catch (\Exception $e) {
+            $this->assertEquals("General error", $e->getMessage());
+            $this->assertInstanceOf('\Eventviva\ImageResizeException', $e);
+            return;
+        }
+        $this->fail();
+    }
 }
 // It's pretty easy to get your attention these days, isn't it? :D


### PR DESCRIPTION
Hereby the requested addition to the Readme file + I changed the unit test to use the ImageResizeException.

With the unit test I had only one 1 issue, it kept saying that it had only code coverage for 1 class. Perhaps I am doing something wrong, or it is because the class is an empty extending one.  

Because it is not blocking, I still hope you will accept this PR, or otherwise point me in the right direction to fix the code coverage.